### PR TITLE
Qapasthailand9 patch 1

### DIFF
--- a/src/data/cl/ko/2013/pots.json
+++ b/src/data/cl/ko/2013/pots.json
@@ -1,72 +1,90 @@
 [
   [
     {
-      "name": "Bayern",
-      "country": "Germany",
-      "bertName": "Bayern München",
-      "group": 0
-    },
-    {
-      "name": "Barcelona",
-      "country": "Spain",
-      "bertName": "FC Barcelona",
-      "group": 1
-    },
-    {
-      "name": "Chelsea",
+      "name": "Man United",
       "country": "England",
-      "bertName": "Chelsea",
-      "group": 2
+      "bertName": "Manchester United",
+      "group": 0
     },
     {
       "name": "Real Madrid",
       "country": "Spain",
       "bertName": "Real Madrid",
-      "group": 3
-    },
-    {
-      "name": "Man United",
-      "country": "England",
-      "bertName": "Manchester United",
-      "group": 4
-    },
-    {
-      "name": "Atlético",
-      "country": "Spain",
-      "bertName": "Atlético Madrid",
-      "group": 5
+      "group": 1
     },
     {
       "name": "Paris",
       "country": "France",
       "bertName": "Paris Saint-Germain",
-      "group": 6
+      "group": 2
     },
     {
+      "name": "Bayern",
+      "country": "Germany",
+      "bertName": "Bayern Munich",
+      "group": 3
+    },
+    {
+      "name": "Chelsea",
+      "country": "England",
+      "bertName": "Chelsea",
+      "group": 4
+    },
+    {     
       "name": "Dortmund",
       "country": "Germany",
       "bertName": "Borussia Dortmund",
+      "group": 5
+    },
+    {
+      "name": "Atlético",
+      "country": "Spain",
+      "bertName": "Atlético Madrid",
+      "group": 6
+    },
+    {
+      "name": "Barcelona",
+      "country": "Spain",
+      "bertName": "FC Barcelona",
       "group": 7
     }
   ],
   [
     {
-      "name": "Arsenal",
-      "country": "England",
-      "bertName": "Arsenal  4",
+      "name": "Leverkusen",
+      "country": "Germany",
+      "bertName": "Bayer Leverkusen",
       "group": 0
     },
     {
-      "name": "Milan",
-      "country": "Italy",
-      "bertName": "AC Milan  4",
+      "name": "Galatasaray",
+      "country": "Turkey",
+      "bertName": "Galatasaray",
       "group": 1
+    },
+    {
+      "name": "Olympiacos",
+      "country": "Greece",
+      "bertName": "Olympiakos Piraeus",
+      "group": 2
+    },
+    {
+      "name": "Man City",
+      "country": "England",
+      "bertName": "Manchester City",
+      "group": 3
     },
     {
       "name": "Schalke",
       "country": "Germany",
-      "bertName": "Schalke 04  4",
-      "group": 2
+      "bertName": "Schalke 04",
+      "group": 4
+    },
+    {
+      "name": "Arsenal",
+      "country": "England",
+      "bertName": "Arsenal",
+      "group": 5
     },
     {
       "name": "Zenit",
@@ -75,27 +93,9 @@
       "group": 3
     },
     {
-      "name": "Man City",
-      "country": "England",
-      "bertName": "Manchester City",
-      "group": 4
-    },
-    {
-      "name": "Olympiacos",
-      "country": "Greece",
-      "bertName": "Olympiakos Piraeus",
-      "group": 5
-    },
-    {
-      "name": "Galatasaray",
-      "country": "Turkey",
-      "bertName": "Galatasaray",
-      "group": 6
-    },
-    {
-      "name": "Leverkusen",
-      "country": "Germany",
-      "bertName": "Bayer Leverkusen",
+      "name": "Milan",
+      "country": "Italy",
+      "bertName": "AC Milan  4",
       "group": 7
     }
   ]

--- a/src/data/el/gs/2020/pots.json
+++ b/src/data/el/gs/2020/pots.json
@@ -215,19 +215,13 @@
       "coefficient": 17
     },
     {
-      "name": "Legia",
-      "country": "Poland",
-      "bertName": "Legia Warsaw",
-      "coefficient": 17
-    }
-  ],
-  [
-    {
       "name": "M Tel-Aviv",
       "country": "Israel",
       "bertName": "Maccabi Tel-Aviv",
       "coefficient": 16.5
-    },
+    }
+  ],
+  [
     {
       "name": "Hoffenheim",
       "country": "Germany",
@@ -245,6 +239,12 @@
       "country": "Moldova",
       "bertName": "Sheriff Tiraspol",
       "coefficient": 12.75
+    },
+    {
+      "name": "Cluj",
+      "country": "Romania",
+      "bertName": "CFR Cluj",
+      "coefficient": 12.5
     },
     {
       "name": "Zorya",


### PR DESCRIPTION
Get Fix Group Stage Changed With Qarabag And Legia Warsaw Can Met To Europa League Play-Off Round If Legia Warsaw Won Againest Drita From Kosovo And Qarabag Lost Molde In Penalty 5-6 After In 120 Minutes Scored 0-0 But Qarabag Uefa Club coefficients Points Is Than Better Legia (21.000:17.000) While CFR Cluj And Djurgarden Met To Europa League 3rd Qualifier Round And KUPS VS Suduva Met To Europa League 3rd Qualifier Round But If Best Uefa Club coefficients In This Route Is CFR Cluj 12.500  Sūduva 6.750 Djurgårdens IF 4.550 And KUPS 2.500 I Hope Inker Get Fix Soon
And I Saw Get 1 Problem Want Fix At Uefa Eruopa League Knockout Round Uefa Europa League 2012/13 2013/14 2014/15 had is Problem  
https://draw.inker.one/#/undefined/undefined/2012
https://draw.inker.one/#/undefined/undefined/2013
https://draw.inker.one/#/undefined/undefined/2014