### PR TITLE
Update pots.json

### DIFF
--- a/src/data/el/gs/2011/pots.json
+++ b/src/data/el/gs/2011/pots.json
@@ -241,9 +241,9 @@
       "coefficient": 10.164
     },
     {
-      "name": "Sion",
-      "country": "Switzerland",
-      "bertName": "FC Sion",
+      "name": "Celtic",
+      "country": "Scotland",
+      "bertName": "Celtic",
       "coefficient": 9.48
     },
     {


### PR DESCRIPTION
In UEL 2011 At Pot 4 Original Is FC Sion From Switzerland But  Celtic lodged protests over the eligibility of a number of the Sion players who participated in the two legs of the play-off round, which Sion won 3–1 aggregate (first leg: 0–0; second leg: 3–1). The UEFA Control and Disciplinary Body accepted the protests and decided to award both matches to Celtic by forfeit (3–0). As a consequence, Celtic qualified for the UEFA Europa League group stage  Celtic Should To Replaced FC Sion