### PR TITLE
fix (BowlBall.tsx): Adjusting display name teams visible for mobile dimension.

### DIFF
--- a/src/ui/bowls/BowlBall.tsx
+++ b/src/ui/bowls/BowlBall.tsx
@@ -32,7 +32,7 @@ const Root = styled(Ball)<RootProps>`
   `}
 
   @media (max-width: 999px) {
-    font-size: ${props => props.selected ? 8 : 0}px;
+    font-size: ${props => props.forceVisible && 8}px;
   }
 `
 


### PR DESCRIPTION
Hello, I noticed that when reducing the screen size for the mobile versions of the project, the names of the teams are not visible when checking the X-Ray checkbox.

So I decided to investigate the bug and found that the font-size logic was switched and checking the value of the selected property instead of the forceVisible property.

So I changed the logic of this font-size. Hope I helped in some way, thanks :)