### PR TITLE
fix (Ball.ts): adjusting color of team names to improve readability.

### DIFF
--- a/src/ui/bowls/TeamBowl/Ball.ts
+++ b/src/ui/bowls/TeamBowl/Ball.ts
@@ -16,6 +16,8 @@ const TeamBall = styled(BowlBall)<Props>`
 
   cursor: ${props => props.noHover ? 'not-allowed' : 'pointer'};
 
+  color: #015cc8;
+
   &:hover {
     ${props => !props.noHover && css`
       background: radial-gradient(#ccf, #ccf);


### PR DESCRIPTION
Hello, I changed the color of the text that contains the name of the teams when checking the X-Ray option, because in the white color the text was a little unreadable, making it difficult to read, so I chose a blue that follows the color tone pattern of the application, making the reading and visualization of the name of the teams easier to be read.

Hope I helped in some way, thanks :)

Any doubt I am available.