### PR TITLE
fix (SelectSeasson.tsx): Adjusting minSeasons champions league.

### DIFF
--- a/src/routes/Navbar/SelectSeason.tsx
+++ b/src/routes/Navbar/SelectSeason.tsx
@@ -17,7 +17,7 @@ import currentSeasonByTournament from '../currentSeasonByTournament'
 import seasonAsString from './seasonAsString'
 
 const minSeasons = {
-  cl: 2000,
+  cl: 2002,
   el: 2009,
   ecl: 2021,
   wc: 2018,

--- a/src/routes/Navbar/SelectSeason.tsx
+++ b/src/routes/Navbar/SelectSeason.tsx
@@ -17,7 +17,7 @@ import currentSeasonByTournament from '../currentSeasonByTournament'
 import seasonAsString from './seasonAsString'
 
 const minSeasons = {
-  cl: 2002,
+  cl: 2003,
   el: 2009,
   ecl: 2021,
   wc: 2018,


### PR DESCRIPTION
Hello, when selecting the elimination round session below the 2002 season, the application crashed because there was no data for the 2000/2001, 2001/2002 seasons, even with the minSeasons property having the 2000 season as its value.

So to solve the problem quickly, while the .json files of the respective seasons are not added, I changed the value of the minSeason property to 2002, which is the season where the .json referring to the year is.

I hope I have helped in some way, and I am available for any questions. Thanks :)