### PR TITLE
Update WK 2022 qualified teams

### DIFF
--- a/src/data/wc-2022.txt
+++ b/src/data/wc-2022.txt
@@ -28,6 +28,6 @@ Canada
 Ecuador
 Saudi Arabia
 Ghana
-UEFA
-AFC/CONMEBOL
-CONCACAF/OFC
+Wales
+Australia
+Costa Rica


### PR DESCRIPTION
Source: https://en.wikipedia.org/wiki/2022_FIFA_World_Cup_qualification#Qualified_teams

Wales have won the UEFA play-offs
Australia have won the AFC v CONMEBOL play-offs
Costa Rica have won the CONCACAF v OFC play-offs